### PR TITLE
Set numpy version to 1.11.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 set -euo pipefail
-pip install numpy
+pip install numpy==1.11.0
 pip install scipy
 pip install pysndfile
 pip install h5py


### PR DESCRIPTION
Running the tests on 1.12.0 causes "TypeError: 'numpy.float64' object cannot be interpreted as an index". Namely on audiofile_tests.F0AnalysisTests, audiofile_tests.KurtosisAnalysisTests, audiofile_tests.PeakAnalysisTests, audiofile_tests.RMSAnalysisTests, audiofile_tests.ZeroXAnalysisTests and test_GenerateRMS.